### PR TITLE
Provide some diagnostic information in the test suite

### DIFF
--- a/t/reactor_uv.t
+++ b/t/reactor_uv.t
@@ -1,9 +1,27 @@
 use Mojo::Base -strict;
 
 use Test::More;
+use Alien::libuv ();
 use IO::Socket::INET;
 use Mojo::Reactor::UV;
 use Scalar::Util 'refaddr';
+use UV ();
+
+diag "\nLibUV information:";
+diag "version        = ", Alien::libuv->config('version');
+diag "cflags         = ", Alien::libuv->cflags;
+diag "cflags_static  = ", Alien::libuv->cflags_static;
+diag "libs           = ", Alien::libuv->libs;
+diag "libs_static    = ", Alien::libuv->libs_static;
+diag "bin_dir        = ", $_ for Alien::libuv->bin_dir;
+diag "Install type   = ", Alien::libuv->install_type;
+diag "Alien::libuv v = ", $Alien::libuv::VERSION;
+
+diag "\nUV Module Information:";
+diag "version        = ", $UV::VERSION;
+
+diag "\nMojo::Reactor::UV Module Information:";
+diag "version        = ", $Mojo::Reactor::UV::VERSION;
 
 # Instantiation
 my $reactor = Mojo::Reactor::UV->new;


### PR DESCRIPTION
When receiving error reports, it'd be helpful if we had a few bits of information to go off of when determining the problem. I've updated the test suite a bit to ```diag``` out some useful bits. When run, we will get some information that looks like:

```log
t/reactor_uv.t ......... # 
# LibUV information:
# version        = 1.9.1
# cflags         =  
# cflags_static  =  
# libs           = -luv -lrt -lpthread -lnsl -ldl 
# libs_static    = -luv -lrt -lpthread -lnsl -ldl 
# Install type   = system
# Alien::libuv v = 1.001
# 
# UV Module Information:
# version        = 1.000008
# 
# Mojo::Reactor::UV Module Information:
# version        = 1.002
t/reactor_uv.t ......... ok
```

The two extra modules used here are already part of the requirements chain as UV is required and UV requires Alien::libuv.